### PR TITLE
CSS ISSUE : larger Property names not breaking up and sliding into Percentage column. #1655 fix

### DIFF
--- a/static/elements/chromedash-metrics.js
+++ b/static/elements/chromedash-metrics.js
@@ -58,6 +58,7 @@ class ChromedashMetrics extends LitElement {
       li > :first-child {
         flex: 1;
         margin-right: 10px;
+        word-break: break-all;
       }
 
       li > :nth-child(2) {


### PR DESCRIPTION
CSS ISSUE : larger Property names not breaking up and sliding into Percentage column. #1655 fix

Large property names should wrap to 2nd line.
The word-break property specifies how words should break when reaching the end of a line.
added { word-break: break-all; } to all <a> inside <li>
PFA screenshot for the same.
image
Expected behavior
Large property names should wrap to 2nd line.
The word-break property specifies how words should break when reaching the end of a line.
image
Solution : Need to apply below CSS to property names.
{
word-break: break-all;
}
Before Fix : 
![image](https://user-images.githubusercontent.com/4961480/147318867-6fe9b44a-3451-49f8-ba52-aa5bb24f2d42.png)

After Fix : 
![image](https://user-images.githubusercontent.com/4961480/147318838-ae8fb662-c46f-445d-8557-33dc1b338b8f.png)
